### PR TITLE
fix: changed peerid to under libp2p

### DIFF
--- a/examples/helia-101/index.js
+++ b/examples/helia-101/index.js
@@ -45,9 +45,9 @@ const helia = await createHelia({
   libp2p
 })
 
-// print out our node's PeerId
-const info = await helia.info()
-console.log(info.peerId)
+// print out our Node's Peer Id
+const peerId = helia.libp2p.peerId
+console.log(peerId)
 
 // create a filesystem on top of Helia, in this case it's UnixFS
 const fs = unixfs(helia)

--- a/examples/helia-101/index.js
+++ b/examples/helia-101/index.js
@@ -45,7 +45,7 @@ const helia = await createHelia({
   libp2p
 })
 
-// print out our Node's Peer Id
+// print out our node's PeerId
 const peerId = helia.libp2p.peerId
 console.log(peerId)
 

--- a/examples/helia-cjs/index.js
+++ b/examples/helia-cjs/index.js
@@ -49,8 +49,8 @@ async function main () {
   })
 
   // print out our node's PeerId
-  const info = await helia.info()
-  console.log(info.peerId)
+  const peerId = helia.libp2p.peerId
+  console.log(peerId)
 
   // create a filesystem on top of Helia, in this case it's UnixFS
   const fs = unixfs(helia)

--- a/examples/helia-webpack/src/app.js
+++ b/examples/helia-webpack/src/app.js
@@ -42,8 +42,9 @@ function App() {
       setHelia(node)
     }
 
-    const info = await node.info()
-    showStatus(`Connecting to ${info.peerId}...`, COLORS.active, info.peerId)
+    const peerId = node.libp2p.peerId
+    console.log(peerId)
+    showStatus(`Connecting to ${peerId}...`, COLORS.active, peerId)
 
     const encoder = new TextEncoder()
 


### PR DESCRIPTION
fix: helia.info().peerId -> helia.libp2p.peerId
I noticed the info method in the [helia](https://github.com/ipfs/helia/blob/main/packages/interface/src/index.ts) interface was removed. this prints the peer id from the libp2p interface