### PR TITLE
docs: remove helia.info() usage

### DIFF
--- a/examples/helia-101/README.md
+++ b/examples/helia-101/README.md
@@ -150,9 +150,7 @@ const helia = await createHelia({
   blockstore
 })
 
-const info = await helia.info()
-
-console.info(info.peerId)
+console.info(helia.libp2p.peerId)
 ```
 
 #### Putting it all together


### PR DESCRIPTION
As this method is no more, as of
https://github.com/ipfs/helia/commit/d15d76cdc40a31bd1e47ca09583cc685583243b9#diff-4b395dbd41dbfcd35086b41ddf60fb8c722f79062cda6d49169fb10fc7afa6dcL67