### PR TITLE
fix: remove timeouts from tests

### DIFF
--- a/examples/helia-script-tag/tests/test.js
+++ b/examples/helia-script-tag/tests/test.js
@@ -1,5 +1,5 @@
-import { test, expect } from '@playwright/test';
-import { playwright } from 'test-util-ipfs-example';
+import { test, expect } from '@playwright/test'
+import { playwright } from 'test-util-ipfs-example'
 
 // Setup
 const play = test.extend({
@@ -8,28 +8,24 @@ const play = test.extend({
 
 play.describe('using script tag:', () => {
   // DOM
-  const status = "#statusValue"
-  const node = "#nodeId"
-  const startHelia = ".e2e-startHelia"
-  const stopHelia = ".e2e-stopHelia"
+  const status = '#statusValue'
+  const node = '#nodeId'
+  const stopHelia = '.e2e-stopHelia'
 
   play.beforeEach(async ({servers, page}) => {
-    await page.goto(`http://localhost:${servers[0].port}/`);
+    await page.goto(`http://localhost:${servers[0].port}/`)
   })
 
   play('should properly initialized a IPFS node and print the status', async ({ page }) => {
-    expect(await page.textContent(status)).toContain("Not Started");
-    await page.waitForSelector(status)
+    // wait for page to init
+    await page.waitForSelector(`${status}:has-text("Not Started")`)
 
-    await new Promise((resolve) => setTimeout(resolve, 2000))
+    // wait for helia to start
+    await page.waitForSelector(`${status}:has-text("Online")`)
+    await page.waitForSelector(`${node}:has-text("12D3")`)
 
-    expect(await page.textContent(status)).toContain("Online");
-    expect(await page.textContent(node)).not.toContain("unknown");
-    expect(await page.textContent(node)).toContain("12D3");
-
+    // wait for helia to stop
     await page.click(stopHelia)
-    await new Promise((resolve) => setTimeout(resolve, 600))
-    expect(await page.textContent(status)).toContain("Offline");
-
-  });
-});
+    await page.waitForSelector(`${status}:has-text("Offline")`)
+  })
+})

--- a/examples/helia-vite-react/src/App.jsx
+++ b/examples/helia-vite-react/src/App.jsx
@@ -9,8 +9,8 @@ function App() {
   const {
     cidString,
     commitText,
-    fetchCommitedText,
-    commitedText,
+    fetchCommittedText,
+    committedText,
   } = useCommitText()
 
   return (
@@ -24,7 +24,7 @@ function App() {
           }`,
           paddingBottom: '4px'
         }}
-      >Helia Status</div> 
+      >Helia Status</div>
       <input
         id="textInput"
         value={text}
@@ -39,13 +39,13 @@ function App() {
       >textCid: {cidString}</div>
       { cidString && (<>
         <button
-          id="fetchCommitedTextButton"
-          onClick={() => fetchCommitedText()}
-        >Fetch Commited Text</button>
+          id="fetchCommittedTextButton"
+          onClick={() => fetchCommittedText()}
+        >Fetch Committed Text</button>
           <div
-            id="commitedTextOutput"
-          >Commited Text: {commitedText}</div>
-        </>) 
+            id="committedTextOutput"
+          >Committed Text: {committedText}</div>
+        </>)
       }
 
     </div>

--- a/examples/helia-vite-react/src/hooks/useCommitText.jsx
+++ b/examples/helia-vite-react/src/hooks/useCommitText.jsx
@@ -8,7 +8,7 @@ export const useCommitText = () => {
   const {helia, fs, error, starting } = useHelia()
   const [cid, setCid] = useState(null)
   const [cidString, setCidString] = useState("")
-  const [commitedText, setCommitedText] = useState("")
+  const [committedText, setCommittedText] = useState("")
 
   const commitText = useCallback(async (text) => {
     if (!error && !starting) {
@@ -28,7 +28,7 @@ export const useCommitText = () => {
     }
   }, [error, starting, helia, fs])
 
-  const fetchCommitedText = useCallback(async () => {
+  const fetchCommittedText = useCallback(async () => {
     let text = ''
     if (!error && !starting) {
       try {
@@ -37,7 +37,7 @@ export const useCommitText = () => {
             stream: true
           })
         }
-        setCommitedText(text)
+        setCommittedText(text)
       } catch (e) {
         console.error(e)
       }
@@ -47,5 +47,5 @@ export const useCommitText = () => {
   }, [error, starting, cid, helia, fs])
   // If one forgets to add helia in the dependency array in commitText, additions to the blockstore will not be picked up by react, leading to operations on fs to hang indefinitely in the generator <suspend> state. As such it would be good practice to ensure to include helia inside the dependency array of all hooks to tell react that the useCallback needs the most up to date helia state
 
-  return { cidString, commitedText, commitText, fetchCommitedText }
+  return { cidString, committedText, commitText, fetchCommittedText }
 }

--- a/examples/helia-vite-react/tests/test.js
+++ b/examples/helia-vite-react/tests/test.js
@@ -11,35 +11,36 @@ play.describe('Use Helia With react and vite', () => {
   const textInput = "#textInput"
   const commitTextButton = "#commitTextButton"
   const cidOutput = "#cidOutput"
-  const fetchCommitedTextButton = "#fetchCommitedTextButton"
-  const commitedTextOutput = "#commitedTextOutput"
+  const fetchCommittedTextButton = "#fetchCommittedTextButton"
+  const committedTextOutput = "#committedTextOutput"
 
   play.beforeEach(async ({servers, page}) => {
     await page.goto(`http://localhost:${servers[0].port}/`);
   })
 
-  play('should properly initialized a Helia node and add/get a file', async ({ page }) => {
+  play('should properly initialize a Helia node and add/get a file', async ({ page }) => {
     // wait for helia node to be online
     const text = 'Hello Helia'
-    console.log('text', text)
     const status = await page.locator(heliaStatus)
     await expect(status).toHaveCSS(
       'border-color',
       'rgb(0, 128, 0)', // green
       {timeout: 7000}
     )
+
     // commit text to the blockstore
     await page.fill(textInput, text)
     await page.click(commitTextButton)
-    
+
     await page.waitForSelector(`${cidOutput}:has-text("bafkreig7i5kbqdnoooievvfextf27eoherluxe2pi3j26hu6zpiauydydy")`)
     const cidOutputContent = await page.textContent(cidOutput)
 
     expect(cidOutputContent).toContain("bafkreig7i5kbqdnoooievvfextf27eoherluxe2pi3j26hu6zpiauydydy");
-    // retreive text from blockstore
-    await page.click(fetchCommitedTextButton)
-    await page.waitForSelector(`${commitedTextOutput}:has-text("${text}")`)
-    const commitedTextOutputLocator = await page.locator(commitedTextOutput)
-    await expect(commitedTextOutputLocator).toHaveText(`Commited Text: ${text}`, {timeout: 2000})
+
+    // retrieve text from blockstore
+    await page.click(fetchCommittedTextButton)
+    await page.waitForSelector(`${committedTextOutput}:has-text("${text}")`)
+    const committedTextOutputLocator = await page.locator(committedTextOutput)
+    await expect(committedTextOutputLocator).toHaveText(`Committed Text: ${text}`, {timeout: 2000})
   });
 });


### PR DESCRIPTION
Better to wait for the selector than have arbitrary timeouts.