### PR TITLE
Updating Readme

### DIFF
--- a/examples/helia-script-tag/README.md
+++ b/examples/helia-script-tag/README.md
@@ -11,7 +11,7 @@
   <br>
   <a href="https://ipfs.github.io/helia/modules/helia.html">Explore the docs</a>
   .
-  <a href="https://codesandbox.io/p/sandbox/helia-script-tag-forked-vptxml">View codesandbox Demo</a>
+  <a href="https://codesandbox.io/p/sandbox/helia-script-tag-vptxml">View codesandbox Demo</a>
   ·
   <a href="https://github.com/ipfs-examples/helia-examples/issues">Report Bug</a>
   ·


### PR DESCRIPTION
Changing the codesandbox link, because the old one runs `npm run dev` which fails because the new one is `npm run serve`: https://github.com/ipfs-examples/helia-examples/blob/main/examples/helia-script-tag/package.json#L12