### PR TITLE
Add packaging example.  Requires electron 28+.  Currently in beta

### DIFF
--- a/examples/helia-electron/dev-app-update.yml
+++ b/examples/helia-electron/dev-app-update.yml
@@ -1,0 +1,3 @@
+provider: generic
+url: https://example.com/auto-updates
+updaterCacheDirName: electron-app-updater

--- a/examples/helia-electron/electron-builder.yml
+++ b/examples/helia-electron/electron-builder.yml
@@ -1,0 +1,43 @@
+appId: com.electron.app
+productName: electron-app
+directories:
+  buildResources: build
+files:
+  - '!**/.vscode/*'
+  - '!src/*'
+  - '!electron.vite.config.{js,ts,mjs,cjs}'
+  - '!{.eslintignore,.eslintrc.cjs,.prettierignore,.prettierrc.yaml,dev-app-update.yml,CHANGELOG.md,README.md}'
+  - '!{.env,.env.*,.npmrc,pnpm-lock.yaml}'
+  - '!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}'
+asarUnpack:
+  - resources/**
+win:
+  executableName: electron-app
+nsis:
+  artifactName: ${name}-${version}-setup.${ext}
+  shortcutName: ${productName}
+  uninstallDisplayName: ${productName}
+  createDesktopShortcut: always
+mac:
+  entitlementsInherit: build/entitlements.mac.plist
+  extendInfo:
+    - NSCameraUsageDescription: Application requests access to the device's camera.
+    - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
+    - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
+    - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
+  notarize: false
+dmg:
+  artifactName: ${name}-${version}.${ext}
+linux:
+  target:
+    - AppImage
+    - snap
+    - deb
+  maintainer: electronjs.org
+  category: Utility
+appImage:
+  artifactName: ${name}-${version}.${ext}
+npmRebuild: true
+publish:
+  provider: generic
+  url: https://example.com/auto-updates

--- a/examples/helia-electron/package.json
+++ b/examples/helia-electron/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "description": "A minimal Electron application with Helia",
+  "author": "example.com",
+  "homepage": "https://www.electronjs.org",
   "keywords": [
     "Electron",
     "IPFS",
@@ -13,14 +15,18 @@
     "clean": "echo 'Nothing to clean...'",
     "start": "electron .",
     "serve": "npm run start",
-    "test": "xvfb-maybe test-node-example test/*"
+    "test": "xvfb-maybe test-node-example test/*",
+    "postinstall": "electron-builder install-app-deps",
+    "build:win": "electron-builder --win --config",
+    "build:mac": "electron-builder --mac --config",
+    "build:linux": "electron-builder --linux --config"
   },
   "dependencies": {
     "helia": "^2.0.3"
   },
   "devDependencies": {
-    "electron": "^27.0.0",
-    "electron-rebuild": "^3.1.1",
+    "electron": "^28.0.0-beta.6",
+    "electron-builder": "^24.6.4",
     "test-ipfs-example": "^1.0.0",
     "xvfb-maybe": "^0.2.1"
   },


### PR DESCRIPTION
The helia-electron example won't package a redistributable with electron 27.

This PR updates electron to 28 beta, and adds an electron-builder example.

I've only tested on linux, so YMMV