### PR TITLE
fix: ts-node workaround

### DIFF
--- a/examples/helia-ts-node/README.md
+++ b/examples/helia-ts-node/README.md
@@ -101,6 +101,14 @@ TypeScript [will not add this for you](https://github.com/microsoft/TypeScript/i
 
 ### ts-node
 
+> :warning: Currently ts-node is [broken on Node.js v20](https://github.com/TypeStrong/ts-node/issues/1997) so the instructions below will not work until the issue is fixed.
+>
+> The workaround is to pass `ts-node/esm` as a loader:
+>
+> ```console
+> $ node --loader ts-node/esm ./src/index.ts
+> ```
+
 #### esm flag
 
 `ts-node` has an `--esm` flag that is slightly counter-intuitively necessary to enable loading `.ts` files for JIT compilation via `import`:
@@ -137,6 +145,8 @@ It is necessary to pass this flag when running `ts-node`
 ```
 
 You can now run ts code using ts-node:
+
+> :warning: As of Node.js v20 the following command will not work, please see the [note above](#ts-node).
 
 ```bash
 > npx ts-node --esm ./src/index.ts

--- a/examples/helia-ts-node/test/index.spec.js
+++ b/examples/helia-ts-node/test/index.spec.js
@@ -4,4 +4,6 @@ import { waitForOutput } from 'test-ipfs-example/node'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-await waitForOutput('Helia is running', 'ts-node', ['--esm', path.resolve(__dirname, '../src/index.ts')])
+// ts-node is currently broken on node 20 - https://github.com/TypeStrong/ts-node/issues/1997
+// await waitForOutput('Helia is running', 'ts-node', ['--esm', path.resolve(__dirname, '../src/index.ts')])
+await waitForOutput('Helia is running', 'node', ['--loader', 'ts-node/esm', path.resolve(__dirname, '../src/index.ts')])


### PR DESCRIPTION
ts-node is [broken on Node.js v20](https://github.com/TypeStrong/ts-node/issues/1997) so add a note to the readme and update the test with a workaround.