### PR TITLE
chore: run monorepo tests in series in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         env:
           CI: true
       - name: Run tests
-        run: npm run test
+        run: npm run test -- --concurrency 1
         env:
           CI: true
 


### PR DESCRIPTION
Reduce the amount of concurrency used during testing to not overload CI machines.