### PR TITLE
fix: tidy up lan example config

### DIFF
--- a/examples/helia-lan-discovery/package.json
+++ b/examples/helia-lan-discovery/package.json
@@ -5,11 +5,11 @@
   "type": "module",
   "description": "Get two helia nodes to connect on LAN without supplying address",
   "scripts": {
-    "server": "cross-env node src/server.js",
-    "client": "cross-env node src/client.js",
+    "server": "node src/server.js",
+    "client": "node src/client.js",
     "test": "npm run test1 && npm run test2",
-    "test1": "timeout 10 npm run server & npm run client",
-    "test2": "timeout 10 npm run client & npm run server"
+    "test1": "npm run server & npm run client",
+    "test2": "npm run client & npm run server"
   },
   "dependencies": {
     "@chainsafe/libp2p-gossipsub": "^11.0.1",
@@ -17,23 +17,16 @@
     "@chainsafe/libp2p-yamux": "^6.0.1",
     "@helia/dag-cbor": "^1.0.3",
     "@libp2p/autonat": "^1.0.5",
-    "@libp2p/circuit-relay-v2": "^1.0.7",
     "@libp2p/identify": "^1.0.6",
     "@libp2p/kad-dht": "^11.0.7",
     "@libp2p/mdns": "^10.0.7",
-    "@libp2p/mplex": "^10.0.7",
     "@libp2p/ping": "^1.0.6",
     "@libp2p/tcp": "^9.0.7",
     "@libp2p/webrtc": "^4.0.10",
     "@libp2p/websockets": "^8.0.7",
-    "@libp2p/webtransport": "^4.0.10",
+    "datastore-core": "^9.2.7",
     "helia": "^2.1.0",
-    "libp2p": "^1.0.10"
-  },
-  "devDependencies": {
-    "@types/jest": "^29.5.11",
-    "cross-env": "^7.0.3",
-    "jest": "^29.7.0",
-    "ts-jest": "^29.1.1"
+    "libp2p": "^1.0.10",
+    "multiformats": "^13.0.1"
   }
 }


### PR DESCRIPTION
Removes missing and uneccessary commands, a bunch of unused deps and adds some missing ones.