### PR TITLE
chore: update nextjs example

### DIFF
--- a/examples/helia-nextjs/README.md
+++ b/examples/helia-nextjs/README.md
@@ -32,7 +32,7 @@ https://github.com/ipfs-examples/helia-examples#prerequisites
 
 ```console
 > npm install
-> npm start
+> npm run dev
 ```
 
 Now open your browser at `http://localhost:3000`

--- a/examples/helia-nextjs/next.config.js
+++ b/examples/helia-nextjs/next.config.js
@@ -1,9 +1,34 @@
-export default {
+/** @type {import('next').NextConfig} */
+const config = {
   reactStrictMode: true,
   images: {
     loader: 'imgix',
     path: 'http://localhost:3000'
   },
-  output: 'export',
-  distDir: 'dist'
+  distDir: 'dist',
+  webpack: (config) => {
+    /**
+     * @see https://github.com/ipfs/helia/issues/553#issuecomment-2158940930
+     */
+    config.externals.push('node-datachannel/polyfill')
+    return config
+  }
+}
+
+export default (phase) => {
+
+  /**
+   * `next start` requires either `undefined` or `'standalone'` output
+   * @type {import('next').NextConfig['output']}
+   */
+  let output = 'standalone'
+  if (process.env.NODE_ENV === 'test') {
+    // test-browser-example requires  `'export'` output
+    output = 'export'
+  }
+
+  return {
+    ...config,
+    output
+  }
 }

--- a/examples/helia-nextjs/package.json
+++ b/examples/helia-nextjs/package.json
@@ -11,21 +11,22 @@
     "serve": "npm run dev",
     "start": "next start",
     "lint": "next lint",
-    "test": "npm run build && test-browser-example test"
+    "test": "cross-env NODE_ENV=test npm run build && test-browser-example test"
   },
   "dependencies": {
-    "helia": "^5.0.0",
+    "helia": "^5.1.0",
     "next": "^14.1.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@playwright/test": "^1.32.1",
-    "eslint": "^8.36.0",
-    "eslint-config-next": "^14.1.0",
-    "interface-datastore": "^8.2.0",
-    "playwright": "^1.32.1",
+    "@playwright/test": "^1.48.1",
+    "cross-env": "^7.0.3",
+    "eslint": "^9.13.0",
+    "eslint-config-next": "^15.0.1",
+    "interface-datastore": "^8.3.1",
+    "playwright": "^1.48.1",
     "rimraf": "^6.0.1",
-    "test-ipfs-example": "^1.0.0"
+    "test-ipfs-example": "^1.3.3"
   }
 }


### PR DESCRIPTION

A few fixes here:

* updates all deps (except nextjs) to latest
* updates the README.md to recommend `npm run dev` instead of `npm start` after npm install
* updates next.config.js to use polyfill recommendation based on https://github.com/ipfs/helia/issues/553#issuecomment-2158940930
* updates the test script to use next config output of `'export'` so tests work properly
