### PR TITLE
ci: set timeout on steps that are known to hang indefinitely after failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,14 @@ jobs:
         run: npm install
       - name: Install Playwright
         run: npx -y playwright install --with-deps
+        # This step has been observed to hang indefinitely when failing to download browsers.
+        timeout-minutes: 10
       - name: Run tests
         run: npm run test
         env:
           CI: true
+        # This step has been observed to hang indefinitely when the browsers weren't correctly downloaded.
+        timeout-minutes: 10
 
   monorepo:
     runs-on: ubuntu-latest
@@ -68,6 +72,8 @@ jobs:
         run: npm install
       - name: Install Playwright
         run: npx -y playwright install --with-deps
+        # This step has been observed to hang indefinitely when failing to download browsers.
+        timeout-minutes: 10
       - name: Run linting
         run: npm run lint
         env:
@@ -76,6 +82,8 @@ jobs:
         run: npm run test -- --concurrency 1
         env:
           CI: true
+        # This step has been observed to hang indefinitely when the browsers weren't correctly downloaded.
+        timeout-minutes: 10
 
   push-changes:
     name: Push changes


### PR DESCRIPTION
I noticed that sometimes running playwright tests, or downloading playwright dependencies, can lead to the steps hanging indefinitely and hitting the default GA timeout of 6 hours. Example: https://github.com/ipfs-examples/helia-examples/actions/runs/12772403282/job/35601903819

In this PR, I propose to add a smaller timeout for those steps. 