### PR TITLE
feat: improve helia 101 example

### DIFF
--- a/examples/helia-101/.gitignore
+++ b/examples/helia-101/.gitignore
@@ -2,6 +2,7 @@ node_modules
 build
 dist
 blockstore
+datastore
 .docs
 .coverage
 node_modules

--- a/examples/helia-101/.gitignore
+++ b/examples/helia-101/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 build
 dist
+blockstore
 .docs
 .coverage
 node_modules

--- a/examples/helia-101/101-basics.js
+++ b/examples/helia-101/101-basics.js
@@ -1,11 +1,11 @@
 /* eslint-disable no-console */
 // @ts-check
 
-import { createHeliaHTTP } from '@helia/http'
-import { unixfs, urlSource } from '@helia/unixfs'
-import { pipeline } from 'stream/promises'
 import * as nodefs from 'fs'
 import { devNull } from 'node:os'
+import { pipeline } from 'stream/promises'
+import { createHeliaHTTP } from '@helia/http'
+import { unixfs, urlSource } from '@helia/unixfs'
 
 // `@helia/http` is an light http-only version Helia with the same API,
 // which is useful for simple use cases, where you don't need p2p networking to provide data to other nodes.
@@ -19,35 +19,32 @@ const fs = unixfs(helia)
 const encoder = new TextEncoder()
 
 // addBytes takes raw bytes and returns a raw block CID for the content
-//The `bytes` value we have passed to `unixfs` has now been turned into a UnixFS DAG and stored in the helia node.
+// The `bytes` value we have passed to `unixfs` has now been turned into a UnixFS DAG and stored in the helia node.
 const cid = await fs.addBytes(encoder.encode('Hello World 101'), {
   onProgress: (evt) => {
     console.info('add event', evt.type, evt.detail)
-  },
+  }
 })
 console.log('Added file:', cid.toString())
 
-
 // Create an empty directory
 const directoryCid = await fs.addDirectory({
-  path: 'my-dir',
+  path: 'my-dir'
 })
 
 // Add a raw block CID to the directory as a file with the name `hello.txt`
 const updatedCid = await fs.cp(cid, directoryCid, 'hello.txt')
 console.log('Directory with added file:', updatedCid)
 
-
 // addFile always returns a directory CID, retaining the filename derived from the `path` argument
 const readmeCid = await fs.addFile({
   content: nodefs.createReadStream('./README.md'),
-  path: './README.md',
+  path: './README.md'
 })
 
 // stat returns a UnixFSStats object, which contains information about the file or directory
 const readmeStats = await fs.stat(readmeCid)
 console.log('README.md stats:', readmeStats)
-
 
 // this decoder will turn Uint8Arrays into strings
 const decoder = new TextDecoder()
@@ -57,14 +54,13 @@ let text = ''
 for await (const chunk of fs.cat(cid, {
   onProgress: (evt) => {
     console.info('cat event', evt.type, evt.detail)
-  },
+  }
 })) {
   text += decoder.decode(chunk, {
-    stream: true,
+    stream: true
   })
 }
 console.log('Added file contents:', text)
-
 
 // Add a file to Helia from a URL
 // Helia will download, and add the file into smaller chunks and return a directory containing a file node `2600-h.htm` with links to the raw blocks of the file
@@ -74,16 +70,15 @@ const urlCid = await fs.addFile(urlSource(url))
 const urlCidStats = await fs.stat(urlCid)
 console.log('File from URL: stats:', urlCidStats)
 
-
 // Instead of loading the file into memory like we did above, we can use the `cat` API, which returns an async iterable,
 // allowing us to stream the file to a writable stream, which we can pipe to devNull, process.stdout, or a file.
 try {
   await pipeline(
     fs.cat(urlCid, {
-      path: '/2600-h.htm',
+      path: '/2600-h.htm'
     }),
     // Uncomment only one of the three lines below:
-    nodefs.createWriteStream(devNull), // devNull is a writable stream that discards all data written to it
+    nodefs.createWriteStream(devNull) // devNull is a writable stream that discards all data written to it
     // process.stdout, // stream file to the console
     // createWriteStream('./war_and_peace.html'), // stream to a file on the local file system
   )

--- a/examples/helia-101/101-basics.js
+++ b/examples/helia-101/101-basics.js
@@ -7,11 +7,36 @@ import { pipeline } from 'stream/promises'
 import * as nodefs from 'fs'
 import { devNull } from 'node:os'
 
-// create a Helia node
+// `@helia/http` is an light http-only version Helia with the same API,
+// which is useful for simple use cases, where you don't need p2p networking to provide data to other nodes.
+// Since this example is focused on UnixFS without p2p networking, we can use the `@helia/http` package.
 const helia = await createHeliaHTTP()
 
 // UnixFS allows you to encode files and directories such that they are addressed by CIDs and can be retrieved by other nodes on the network
 const fs = unixfs(helia)
+
+// we will use this TextEncoder to turn strings into Uint8Arrays which we can add to the node
+const encoder = new TextEncoder()
+
+// addBytes takes raw bytes and returns a raw block CID for the content
+//The `bytes` value we have passed to `unixfs` has now been turned into a UnixFS DAG and stored in the helia node.
+const cid = await fs.addBytes(encoder.encode('Hello World 101'), {
+  onProgress: (evt) => {
+    console.info('add event', evt.type, evt.detail)
+  },
+})
+console.log('Added file:', cid.toString())
+
+
+// Create an empty directory
+const directoryCid = await fs.addDirectory({
+  path: 'my-dir',
+})
+
+// Add a raw block CID to the directory as a file with the name `hello.txt`
+const updatedCid = await fs.cp(cid, directoryCid, 'hello.txt')
+console.log('Directory with added file:', updatedCid)
+
 
 // addFile always returns a directory CID, retaining the filename derived from the `path` argument
 const readmeCid = await fs.addFile({
@@ -23,16 +48,6 @@ const readmeCid = await fs.addFile({
 const readmeStats = await fs.stat(readmeCid)
 console.log('README.md stats:', readmeStats)
 
-// we will use this TextEncoder to turn strings into Uint8Arrays
-const encoder = new TextEncoder()
-
-// add the bytes and receive a raw block CID for the content because it's small enough to fit into a single block
-const cid = await fs.addBytes(encoder.encode('Hello World 101'), {
-  onProgress: (evt) => {
-    console.info('add event', evt.type, evt.detail)
-  },
-})
-console.log('Added file:', cid.toString())
 
 // this decoder will turn Uint8Arrays into strings
 const decoder = new TextDecoder()
@@ -50,32 +65,27 @@ for await (const chunk of fs.cat(cid, {
 }
 console.log('Added file contents:', text)
 
-// Create an empty directory
-const directoryCid = await fs.addDirectory({
-  path: 'my-dir',
-})
-
-// Add a file to the directory
-const updatedCid = await fs.cp(cid, directoryCid, 'hello.txt')
-console.log('Directory with added file:', updatedCid)
 
 // Add a file to Helia from a URL
-// This will download, chunk the file into smaller chunks and return a directory containing the file CID with links to the raw blocks of the file
+// Helia will download, and add the file into smaller chunks and return a directory containing a file node `2600-h.htm` with links to the raw blocks of the file
 const url = 'https://www.gutenberg.org/files/2600/2600-h/2600-h.htm'
 const urlCid = await fs.addFile(urlSource(url))
 
 const urlCidStats = await fs.stat(urlCid)
 console.log('File from URL: stats:', urlCidStats)
 
-// Helia UnixFS returns an async iterable, allowing integration with other streams
-// Here we use the pipeline function to pipe the stream to devNull to avoid writing to the file system
+
+// Instead of loading the file into memory like we did above, we can use the `cat` API, which returns an async iterable,
+// allowing us to stream the file to a writable stream, which we can pipe to devNull, process.stdout, or a file.
 try {
   await pipeline(
     fs.cat(urlCid, {
       path: '/2600-h.htm',
     }),
-    nodefs.createWriteStream(devNull),
-    // createWriteStream('./war_and_peace.html'), // uncomment this to write to the file system
+    // Uncomment only one of the three lines below:
+    nodefs.createWriteStream(devNull), // devNull is a writable stream that discards all data written to it
+    // process.stdout, // stream file to the console
+    // createWriteStream('./war_and_peace.html'), // stream to a file on the local file system
   )
 } catch (err) {
   console.error('Pipeline failed', err)

--- a/examples/helia-101/101-basics.js
+++ b/examples/helia-101/101-basics.js
@@ -19,6 +19,7 @@ const fs = unixfs(helia)
 const encoder = new TextEncoder()
 
 // addBytes takes raw bytes and returns a raw block CID for the content
+// (larger (over 1 MiB) binary arrays are chunked and return a dag-pb block CID instead)
 // The `bytes` value we have passed to `unixfs` has now been turned into a UnixFS DAG and stored in the helia node.
 const cid = await fs.addBytes(encoder.encode('Hello World 101'), {
   onProgress: (evt) => {

--- a/examples/helia-101/101-basics.js
+++ b/examples/helia-101/101-basics.js
@@ -42,9 +42,13 @@ const readmeCid = await fs.addFile({
   path: './README.md'
 })
 
-// stat returns a UnixFSStats object, which contains information about the file or directory
+// stat returns a UnixFSStats object, which contains information about the directory
 const readmeStats = await fs.stat(readmeCid)
 console.log('README.md stats:', readmeStats)
+
+// To get the size of a directory, we need extended stats, which traverse the DAG
+const readmeExStats = await fs.stat(readmeCid, { extended: true })
+console.log('README.md stats (extended):', readmeExStats)
 
 // this decoder will turn Uint8Arrays into strings
 const decoder = new TextDecoder()

--- a/examples/helia-101/101-basics.js
+++ b/examples/helia-101/101-basics.js
@@ -29,9 +29,7 @@ const cid = await fs.addBytes(encoder.encode('Hello World 101'), {
 console.log('Added file:', cid.toString())
 
 // Create an empty directory
-const directoryCid = await fs.addDirectory({
-  path: 'my-dir'
-})
+const directoryCid = await fs.addDirectory()
 
 // Add a raw block CID to the directory as a file with the name `hello.txt`
 const updatedCid = await fs.cp(cid, directoryCid, 'hello.txt')

--- a/examples/helia-101/101-basics.js
+++ b/examples/helia-101/101-basics.js
@@ -1,47 +1,82 @@
 /* eslint-disable no-console */
+// @ts-check
 
 import { createHeliaHTTP } from '@helia/http'
-import { unixfs } from '@helia/unixfs'
+import { unixfs, urlSource } from '@helia/unixfs'
+import { pipeline } from 'stream/promises'
+import * as nodefs from 'fs'
+import { devNull } from 'node:os'
 
 // create a Helia node
 const helia = await createHeliaHTTP()
 
-// create a filesystem on top of Helia, in this case it's UnixFS
+// UnixFS allows you to encode files and directories such that they are addressed by CIDs and can be retrieved by other nodes on the network
 const fs = unixfs(helia)
 
-// add a file and wrap in a directory
+// addFile always returns a directory CID, retaining the filename derived from the `path` argument
 const readmeCid = await fs.addFile({
-  path: './README.md'
-}, {
-  wrapWithDirectory: true
+  content: nodefs.createReadStream('./README.md'),
+  path: './README.md',
 })
 
-console.log('Added README.md file:', readmeCid.toString())
+// stat returns a UnixFSStats object, which contains information about the file or directory
+const readmeStats = await fs.stat(readmeCid)
+console.log('README.md stats:', readmeStats)
 
 // we will use this TextEncoder to turn strings into Uint8Arrays
 const encoder = new TextEncoder()
 
-// add the bytes to your node and receive a unique content identifier
+// add the bytes and receive a raw block CID for the content because it's small enough to fit into a single block
 const cid = await fs.addBytes(encoder.encode('Hello World 101'), {
   onProgress: (evt) => {
     console.info('add event', evt.type, evt.detail)
-  }
+  },
 })
-
 console.log('Added file:', cid.toString())
 
 // this decoder will turn Uint8Arrays into strings
 const decoder = new TextDecoder()
 let text = ''
 
+// Read the file into memory and print it to the console
 for await (const chunk of fs.cat(cid, {
   onProgress: (evt) => {
     console.info('cat event', evt.type, evt.detail)
-  }
+  },
 })) {
   text += decoder.decode(chunk, {
-    stream: true
+    stream: true,
   })
 }
-
 console.log('Added file contents:', text)
+
+// Create an empty directory
+const directoryCid = await fs.addDirectory({
+  path: 'my-dir',
+})
+
+// Add a file to the directory
+const updatedCid = await fs.cp(cid, directoryCid, 'hello.txt')
+console.log('Directory with added file:', updatedCid)
+
+// Add a file to Helia from a URL
+// This will download, chunk the file into smaller chunks and return a directory containing the file CID with links to the raw blocks of the file
+const url = 'https://www.gutenberg.org/files/2600/2600-h/2600-h.htm'
+const urlCid = await fs.addFile(urlSource(url))
+
+const urlCidStats = await fs.stat(urlCid)
+console.log('File from URL: stats:', urlCidStats)
+
+// Helia UnixFS returns an async iterable, allowing integration with other streams
+// Here we use the pipeline function to pipe the stream to devNull to avoid writing to the file system
+try {
+  await pipeline(
+    fs.cat(urlCid, {
+      path: '/2600-h.htm',
+    }),
+    nodefs.createWriteStream(devNull),
+    // createWriteStream('./war_and_peace.html'), // uncomment this to write to the file system
+  )
+} catch (err) {
+  console.error('Pipeline failed', err)
+}

--- a/examples/helia-101/201-storage.js
+++ b/examples/helia-101/201-storage.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
 // @ts-check
+import { createHeliaHTTP } from '@helia/http'
 import { unixfs } from '@helia/unixfs'
 import { MemoryBlockstore } from 'blockstore-core'
-import { createHeliaHTTP } from '@helia/http'
 import { FsBlockstore } from 'blockstore-fs'
 
 // the blockstore is where we store the blocks that make up files. this blockstore
@@ -14,7 +14,7 @@ import { FsBlockstore } from 'blockstore-fs'
 
 // Create a new Helia node with an in-memory blockstore
 const helia1 = await createHeliaHTTP({
-  blockstore: new MemoryBlockstore(),
+  blockstore: new MemoryBlockstore()
 })
 
 // create a UnixFS filesystem on top of Helia
@@ -48,5 +48,3 @@ try {
 }
 
 process.exit(0)
-
-

--- a/examples/helia-101/201-storage.js
+++ b/examples/helia-101/201-storage.js
@@ -47,4 +47,5 @@ try {
   console.log('Added file:', cid2.toString())
 }
 
-process.exit(0)
+await helia1.stop()
+await helia2.stop()

--- a/examples/helia-101/201-storage.js
+++ b/examples/helia-101/201-storage.js
@@ -1,8 +1,9 @@
 /* eslint-disable no-console */
-
+// @ts-check
 import { unixfs } from '@helia/unixfs'
 import { MemoryBlockstore } from 'blockstore-core'
-import { createHelia } from 'helia'
+import { createHeliaHTTP } from '@helia/http'
+import { FsBlockstore } from 'blockstore-fs'
 
 // the blockstore is where we store the blocks that make up files. this blockstore
 // stores everything in-memory - other blockstores are available:
@@ -10,41 +11,42 @@ import { createHelia } from 'helia'
 //   - https://www.npmjs.com/package/blockstore-idb - an IndexDB blockstore (for use in browsers)
 //   - https://www.npmjs.com/package/blockstore-level - a LevelDB blockstore (for node or browsers,
 //                                        though storing files in a database is rarely a good idea)
-const blockstore = new MemoryBlockstore()
 
-// create a Helia node
-const helia = await createHelia({
-  blockstore
+// Create a new Helia node with an in-memory blockstore
+const helia1 = await createHeliaHTTP({
+  blockstore: new MemoryBlockstore(),
 })
 
-// create a filesystem on top of Helia, in this case it's UnixFS
-const fs = unixfs(helia)
+// create a UnixFS filesystem on top of Helia
+const fs1 = unixfs(helia1)
 
 // we will use this TextEncoder to turn strings into Uint8Arrays
 const encoder = new TextEncoder()
 
+const message = 'Hello World 201'
+
 // add the bytes to your node and receive a unique content identifier
-const cid = await fs.addBytes(encoder.encode('Hello World 201'))
+const cid1 = await fs1.addBytes(encoder.encode(message))
 
-console.log('Added file:', cid.toString())
+console.log('Added file contents:', message)
 
-// create a second Helia node using the same blockstore
-const helia2 = await createHelia({
-  blockstore
+// Create a new Helia node with a filesystem blockstore
+const helia2 = await createHeliaHTTP({
+  blockstore: new FsBlockstore('./blockstore')
 })
 
-// create a second filesystem
 const fs2 = unixfs(helia2)
-
-// this decoder will turn Uint8Arrays into strings
-const decoder = new TextDecoder()
-let text = ''
-
-// read the file from the blockstore using the second Helia node
-for await (const chunk of fs2.cat(cid)) {
-  text += decoder.decode(chunk, {
-    stream: true
-  })
+try {
+  // Check if the CID is in the blockstore, which will be true if we ran this script before
+  const stats = await fs2.stat(cid1, { offline: true }) // `offline: true` will prevent the node from trying to fetch the block from the network
+  console.log(`Found ${cid1.toString()} in blockstore:`, stats)
+} catch (error) {
+  console.log("CID can't be found in the blockstore. We will add it now.")
+  // If the CID is not in the blockstore, we will add it now
+  const cid2 = await fs2.addBytes(encoder.encode(message))
+  console.log('Added file:', cid2.toString())
 }
 
-console.log('Added file contents:', text)
+process.exit(0)
+
+

--- a/examples/helia-101/301-networking.js
+++ b/examples/helia-101/301-networking.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+// @ts-check
 
 import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
@@ -91,3 +92,6 @@ for await (const chunk of fs2.cat(cid)) {
 }
 
 console.log('Fetched file contents:', text)
+
+await node1.stop()
+await node2.stop()

--- a/examples/helia-101/401-providing.js
+++ b/examples/helia-101/401-providing.js
@@ -1,0 +1,79 @@
+/* eslint-disable no-console */
+// @ts-check
+import { unixfs } from '@helia/unixfs'
+import { createHelia } from 'helia'
+import { NotFoundError } from '@libp2p/interface'
+import { FsBlockstore } from 'blockstore-fs'
+import { FsDatastore } from 'datastore-fs'
+
+const helia = await createHelia()
+
+// log when our addresses changes
+helia.libp2p.addEventListener('self:peer:update', (evt) => {
+  console.log(
+    'self:peer:update',
+    evt.detail.peer.addresses.map((a) => a.multiaddr.toString()),
+  )
+})
+
+console.log('Created Helia node with PeerID:', helia.libp2p.peerId.toString())
+
+// create a filesystem on top of Helia, in this case it's UnixFS
+const fs = unixfs(helia)
+
+// we will use this TextEncoder to turn strings into Uint8Arrays
+const encoder = new TextEncoder()
+
+const text = 'Hello World 🗺️🌎🌍🌏 401!'
+
+// add the bytes to your node and receive a unique content identifier
+let cid = await fs.addFile({
+  content: encoder.encode(text),
+  path: './hello-world.txt',
+})
+console.log('Added file:', cid.toString())
+
+
+// Run garbage collection to remove unpinned blocks
+await helia.gc({
+  onProgress: (evt) => {
+    console.info('gc event', evt.type, evt.detail)
+  },
+})
+
+// This will fail because the block is not pinned
+try {
+  const stats = await fs.stat(cid, { offline: true }) // offline to avoid fetching the block from the network
+  console.log('Stats:', stats)
+} catch (err) {
+  if (err?.name === 'NotFoundError') {
+    console.log('Block not found, as expected')
+  } else {
+    throw err
+  }
+}
+
+// Add the same bytes again, this time we will pin them
+cid = await fs.addFile({
+  content: encoder.encode(text),
+  path: './hello-world.txt',
+})
+console.log('Added file again:', cid.toString())
+
+// Pin the block and add some metadata
+for await (const pinnedCid of helia.pins.add(cid, {
+  metadata: {
+    added: new Date().toISOString(),
+    addedBy: '401-providing example',
+  },
+})) {
+  console.log('Pinned CID to prevent garbage collection:', pinnedCid.toString())
+}
+
+const pin = await helia.pins.get(cid)
+console.log('Pin:', pin)
+
+// Provide the block to the DHT so that other nodes can find and retrieve it
+await helia.routing.provide(cid)
+
+console.log('CID provided to the DHT:', cid.toString())

--- a/examples/helia-101/401-providing.js
+++ b/examples/helia-101/401-providing.js
@@ -9,7 +9,7 @@ const helia = await createHelia()
 helia.libp2p.addEventListener('self:peer:update', (evt) => {
   console.log(
     'self:peer:update',
-    evt.detail.peer.addresses.map((a) => a.multiaddr.toString()),
+    evt.detail.peer.addresses.map((a) => a.multiaddr.toString())
   )
 })
 
@@ -26,16 +26,15 @@ const text = 'Hello World 🗺️🌎🌍🌏 401!'
 // add the bytes to your node and receive a unique content identifier
 let cid = await fs.addFile({
   content: encoder.encode(text),
-  path: './hello-world.txt',
+  path: './hello-world.txt'
 })
 console.log('Added file:', cid.toString())
-
 
 // Run garbage collection to remove unpinned blocks
 await helia.gc({
   onProgress: (evt) => {
     console.info('gc event', evt.type, evt.detail)
-  },
+  }
 })
 
 // This will fail because the block is not pinned
@@ -53,7 +52,7 @@ try {
 // Add the same bytes again, this time we will pin them
 cid = await fs.addFile({
   content: encoder.encode(text),
-  path: './hello-world.txt',
+  path: './hello-world.txt'
 })
 console.log('Added file again:', cid.toString())
 
@@ -61,8 +60,8 @@ console.log('Added file again:', cid.toString())
 for await (const pinnedCid of helia.pins.add(cid, {
   metadata: {
     added: new Date().toISOString(),
-    addedBy: '401-providing example',
-  },
+    addedBy: '401-providing example'
+  }
 })) {
   console.log('Pinned CID to prevent garbage collection:', pinnedCid.toString())
 }

--- a/examples/helia-101/401-providing.js
+++ b/examples/helia-101/401-providing.js
@@ -73,3 +73,5 @@ console.log('Pin:', pin)
 await helia.routing.provide(cid)
 
 console.log('CID provided to the DHT:', cid.toString())
+
+await helia.stop()

--- a/examples/helia-101/401-providing.js
+++ b/examples/helia-101/401-providing.js
@@ -2,9 +2,6 @@
 // @ts-check
 import { unixfs } from '@helia/unixfs'
 import { createHelia } from 'helia'
-import { NotFoundError } from '@libp2p/interface'
-import { FsBlockstore } from 'blockstore-fs'
-import { FsDatastore } from 'datastore-fs'
 
 const helia = await createHelia()
 

--- a/examples/helia-101/README.md
+++ b/examples/helia-101/README.md
@@ -73,74 +73,39 @@ Make sure you have installed all of the following prerequisites on your developm
 
 ## Usage
 
-In this tutorial, we go through spawning a Helia node, adding a file and cating the file [CID][] locally and through the gateway.
+In this tutorial, we go through spawning a Helia node and interacting with [UnixFS](https://docs.ipfs.tech/concepts/glossary/#unixfs), adding bytes, directories, and files to the node and retrieving them.
 
-It it split into three parts, each part builds on the previous one - basics, storage and finally networking.
+It is split into three parts, each part builds on the previous one - basics of interaction with UnixFS, storage and finally networking.
 
 For this tutorial, you need to install all dependencies in the `package.json` using `npm install`.
 
 ### 101 - Basics
 
-In the [101-basics.js](./101-basics.js) example the first thing we do is create a Helia node:
+The [first example](./101-basics.js) goes into the the basics of interacting with UnixFS, adding bytes, directories, and files to the node and retrieving them.
 
-```js
-import { createHelia } from 'helia'
+To run it, use the following command:
 
-// create a Helia node
-const helia = await createHelia()
+```console
+> npm run 101-basics
 ```
-
-This node allows us to add blocks and later to retrieve them.
-
-Next we use `@helia/unixfs` to add some data to our node:
-
-```js
-import { unixfs } from '@helia/unixfs'
-
-// create a filesystem on top of Helia, in this case it's UnixFS
-const fs = unixfs(helia)
-
-// we will use this TextEncoder to turn strings into Uint8Arrays
-const encoder = new TextEncoder()
-const bytes = encoder.encode('Hello World 101')
-
-// add the bytes to your node and receive a unique content identifier
-const cid = await fs.addBytes(bytes)
-
-console.log('Added file:', cid.toString())
-```
-
-The `bytes` value we have passed to `unixfs` has now been turned into a UnixFS DAG and stored in the helia node.
-
-We can access it by using the `cat` API and passing the [CID][] that was returned from the invocation of `addBytes`:
-
-```js
-// this decoder will turn Uint8Arrays into strings
-const decoder = new TextDecoder()
-let text = ''
-
-for await (const chunk of fs.cat(cid)) {
-  text += decoder.decode(chunk, {
-    stream: true
-  })
-}
-
-console.log('Added file contents:', text)
-```
-
-That's it!  We've created a Helia node, added a file to it, and retrieved that file.
-
-Next we will look at where the bytes that make up the file go.
 
 ### 201 - Storage
 
-Out of the box Helia will store all data in-memory.  This makes it easy to get started, and to create short-lived nodes that do not persist state between restarts, but what if you want to store large amounts of data for long amounts of time?
+Out of the box Helia will store all data in-memory. This makes it easy to get started, and to create short-lived nodes that do not persist state between restarts, but what if you want to store large amounts of data for long amounts of time?
 
 Take a look at [201-storage.js](./201-storage.js) where we explore how to configure different types of persistent storage for your Helia node.
 
+To run it, use the following command:
+
+```console
+> npm run 201-storage
+```
+
+If you run the example twice: you may notice that the second time the file is found in the blockstore without being added again.
+
 #### Blockstore
 
-At it's heart the Interplanetary Filesystem is about blocks.  When you add a file to your local Helia node, it is split up into a number of blocks, all of which are stored in a [blockstore](https://www.npmjs.com/package/interface-blockstore).
+At it's heart IPFS is about blocks of data addressed by a [CID][]. When you add a file to your local Helia node, it is split up into a number of blocks, all of which are stored in a [blockstore](https://www.npmjs.com/package/interface-blockstore).
 
 Each block has a [CID][], an identifier that is unique to that block and can be used to request it from other nodes in the network.
 

--- a/examples/helia-101/README.md
+++ b/examples/helia-101/README.md
@@ -69,13 +69,14 @@ Make sure you have installed all of the following prerequisites on your developm
 > npm run 101-basics
 > npm run 201-storage
 > npm run 301-networking
+> npm run 401-providing
 ```
 
 ## Usage
 
 In this tutorial, we go through spawning a Helia node and interacting with [UnixFS](https://docs.ipfs.tech/concepts/glossary/#unixfs), adding bytes, directories, and files to the node and retrieving them.
 
-It is split into three parts, each part builds on the previous one - basics of interaction with UnixFS, storage and finally networking.
+It is split into multiple parts, each part builds on the previous one - basics of interaction with UnixFS, storage, networking, and finally providing, garbage collection and pinning.
 
 For this tutorial, you need to install all dependencies in the `package.json` using `npm install`.
 
@@ -193,6 +194,25 @@ const libp2p = await createLibp2p({
 })
 ```
 
+### 401 - Providing
+
+The final example is [401-providing.js](./401-providing.js).
+
+This example shows:
+
+- How to run garbage collection,
+- Pin blocks to prevent them from being garbage collected
+- Add metadata to pins
+- Provide it to the DHT so that other nodes can find and retrieve it.
+
+To run it, use the following command:
+
+```console
+> npm run 401-providing
+```
+
+
+
 ### Putting it all together
 
 Since your Helia node is configured with a libp2p node, you can go to an IPFS Gateway and load the printed hash. Go ahead and try it!
@@ -205,7 +225,7 @@ Added file: bafkreife2klsil6kaxqhvmhgldpsvk5yutzm4i5bgjoq6fydefwtihnesa
 # https://ipfs.io/ipfs/bafkreife2klsil6kaxqhvmhgldpsvk5yutzm4i5bgjoq6fydefwtihnesa
 ```
 
-That's it! You just added and retrieved a file from the Distributed Web!
+That's it! You just added and retrieved a file from IPFS!
 
 _For more examples, please refer to the [Documentation](#documentation)_
 

--- a/examples/helia-101/package.json
+++ b/examples/helia-101/package.json
@@ -20,6 +20,7 @@
     "@libp2p/identify": "^3.0.26",
     "@libp2p/tcp": "^10.1.7",
     "blockstore-core": "^5.0.2",
+    "blockstore-fs": "^2.0.2",
     "datastore-core": "^10.0.2",
     "helia": "^5.3.0",
     "libp2p": "^2.8.1"

--- a/examples/helia-101/package.json
+++ b/examples/helia-101/package.json
@@ -9,6 +9,7 @@
     "101-basics": "node 101-basics.js",
     "201-storage": "node 201-storage.js",
     "301-networking": "node 301-networking.js",
+    "401-providing": "node 401-providing.js",
     "test": "test-node-example test/*"
   },
   "dependencies": {
@@ -22,6 +23,7 @@
     "blockstore-core": "^5.0.2",
     "blockstore-fs": "^2.0.2",
     "datastore-core": "^10.0.2",
+    "datastore-fs": "^10.0.2",
     "helia": "^5.3.0",
     "libp2p": "^2.8.1"
   },

--- a/examples/helia-101/package.json
+++ b/examples/helia-101/package.json
@@ -12,19 +12,19 @@
     "test": "test-node-example test/*"
   },
   "dependencies": {
-    "@chainsafe/libp2p-noise": "^16.0.0",
+    "@chainsafe/libp2p-noise": "^16.0.3",
     "@chainsafe/libp2p-yamux": "^7.0.1",
-    "@helia/http": "^2.0.0",
-    "@helia/unixfs": "^4.0.0",
-    "@libp2p/bootstrap": "^11.0.7",
-    "@libp2p/identify": "^3.0.7",
-    "@libp2p/tcp": "^10.0.8",
+    "@helia/http": "^2.0.5",
+    "@helia/unixfs": "^4.0.3-c0bf36e",
+    "@libp2p/bootstrap": "^11.0.31",
+    "@libp2p/identify": "^3.0.26",
+    "@libp2p/tcp": "^10.1.7",
     "blockstore-core": "^5.0.2",
     "datastore-core": "^10.0.2",
-    "helia": "^5.0.0",
-    "libp2p": "^2.1.6"
+    "helia": "^5.3.0",
+    "libp2p": "^2.8.1"
   },
   "devDependencies": {
-    "test-ipfs-example": "^1.0.0"
+    "test-ipfs-example": "^1.3.3"
   }
 }

--- a/examples/helia-101/package.json
+++ b/examples/helia-101/package.json
@@ -13,19 +13,19 @@
     "test": "test-node-example test/*"
   },
   "dependencies": {
-    "@chainsafe/libp2p-noise": "^16.0.3",
+    "@chainsafe/libp2p-noise": "^16.1.0",
     "@chainsafe/libp2p-yamux": "^7.0.1",
     "@helia/http": "^2.0.5",
-    "@helia/unixfs": "^4.0.3-c0bf36e",
-    "@libp2p/bootstrap": "^11.0.31",
-    "@libp2p/identify": "^3.0.26",
-    "@libp2p/tcp": "^10.1.7",
+    "@helia/unixfs": "^5.0.0",
+    "@libp2p/bootstrap": "^11.0.32",
+    "@libp2p/identify": "^3.0.27",
+    "@libp2p/tcp": "^10.1.8",
     "blockstore-core": "^5.0.2",
     "blockstore-fs": "^2.0.2",
     "datastore-core": "^10.0.2",
     "datastore-fs": "^10.0.2",
     "helia": "^5.3.0",
-    "libp2p": "^2.8.1"
+    "libp2p": "^2.8.2"
   },
   "devDependencies": {
     "test-ipfs-example": "^1.3.3"

--- a/examples/helia-101/test/index.spec.js
+++ b/examples/helia-101/test/index.spec.js
@@ -9,3 +9,5 @@ await waitForOutput('Added file contents: Hello World 101', 'node', [path.resolv
 await waitForOutput('Added file contents: Hello World 201', 'node', [path.resolve(__dirname, '../201-storage.js')])
 
 await waitForOutput('Fetched file contents: Hello World 301', 'node', [path.resolve(__dirname, '../301-networking.js')])
+
+await waitForOutput('CID provided to the DHT:', 'node', [path.resolve(__dirname, '../401-providing.js')])


### PR DESCRIPTION
## What

- 101: adapt example to the changes introduced by https://github.com/ipfs/helia/pull/754
- 101: add more examples on how to use UnixFS in 101, including nuances around bytes/files/directories 
- 201: change to focus on a single node and different block stores
- 201: use helia/http since we don't care about providing
- 401: add new example showing gc, providing, and pinning
- README:  update for the example. Move code specific docs inline rather than README.

## Additions for a followup

- Configuring block brokers & routers
- CAR files
- MFS

## TODO

- [x] Fix failing test (failing because of https://github.com/libp2p/js-libp2p/issues/3049) no longer relevant since we only create one node and 
- [x] Update @helia/unixfs to 5 once https://github.com/ipfs/helia/pull/766 is merged
- [x] Update the README